### PR TITLE
Uptime: Add an 's' if the unit isn't 1

### DIFF
--- a/commands.ts
+++ b/commands.ts
@@ -133,7 +133,7 @@ const commands: {
         do {
             const divisor = divisors.pop()
             const unit = uptime % divisor
-            buffer.push(unit > 1 ? unit + ' ' + units.pop() + 's' : unit + ' ' + units.pop())
+            buffer.push(unit + ' ' + (unit !== 1 ? units.pop() + 's' : units.pop()))
             uptime = ~~(uptime / divisor)
         } while (uptime)
 


### PR DESCRIPTION
1. This syntax is less repetitive, and works on my bot.
2. This avoids odd-looking '0 minute/hour' messages, reserving the singular form for only if the unit is equal to 1.
